### PR TITLE
Improved C# implementation to avoid errors

### DIFF
--- a/CS/PdfAPIAzureKeyVaultSample/AzureKeyVaultClient.cs
+++ b/CS/PdfAPIAzureKeyVaultSample/AzureKeyVaultClient.cs
@@ -1,4 +1,5 @@
 # region #using
+using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
@@ -9,6 +10,7 @@ using DevExpress.Pdf;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
 #endregion
 
 
@@ -18,82 +20,109 @@ namespace PdfAPIAzureKeyVaultSample
     #region client
     public class AzureKeyVaultClient
     {
-        public static AzureKeyVaultClient CreateClient(string keyVaultUrl)
+        public static AzureKeyVaultClient CreateClient(Uri keyVaultUri)
         {
-            return new AzureKeyVaultClient(new KeyClient(new Uri(keyVaultUrl), new DefaultAzureCredential()));
+            var tokenCredential = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                ExcludeInteractiveBrowserCredential = false,
+                ExcludeVisualStudioCodeCredential = true
+            });
+
+            return new AzureKeyVaultClient(new KeyClient(keyVaultUri, tokenCredential), tokenCredential);
         }
 
         readonly KeyClient client;
 
-        DefaultAzureCredential defaultAzureCredential;
-        AzureKeyVaultClient(KeyClient client)
+        TokenCredential clientCredentials;
+        AzureKeyVaultClient(KeyClient client, TokenCredential cryptoClientCredential)
         {
             this.client = client;
-
-            var credentialOptions = new DefaultAzureCredentialOptions
-            {
-                ExcludeInteractiveBrowserCredential = false,
-                ExcludeVisualStudioCodeCredential = true
-            };
-            defaultAzureCredential = new DefaultAzureCredential(credentialOptions);
+            this.clientCredentials = cryptoClientCredential;
         }
-        public byte[] Sign(string keyId, SignatureAlgorithm algorithm, byte[] digest)
+        public byte[] Sign(string certificateName, SignatureAlgorithm algorithm, byte[] digest, string version = null)
         {
-            KeyVaultKey cloudRsaKey = client.GetKey(keyId);
-            var rsaCryptoClient = new CryptographyClient(cloudRsaKey.Id, defaultAzureCredential);
+            KeyVaultKey cloudRsaKey = client.GetKey(certificateName, version: version);
+            var rsaCryptoClient = new CryptographyClient(cloudRsaKey.Id, clientCredentials);
 
             SignResult rsaSignResult = rsaCryptoClient.Sign(algorithm, digest);
-            Debug.WriteLine($"Signed digest using the algorithm {rsaSignResult.Algorithm}, with key {rsaSignResult.KeyId}. " +
-                $"The resulting signature is {Convert.ToBase64String(rsaSignResult.Signature)}");
-
+            Debug.WriteLine($"Signed digest using the algorithm {rsaSignResult.Algorithm}, " +
+                $"with key {rsaSignResult.KeyId}. The resulting signature is {Convert.ToBase64String(rsaSignResult.Signature)}");
             return rsaSignResult.Signature;
         }
 
-        public byte[] GetCertificateData(string keyVaultUrl, string certificateIdentifier)
+        public KeyVaultCertificateWithPolicy GetCertificateData(string keyId)
         {
-            var certificateClient = new CertificateClient(new Uri(keyVaultUrl), defaultAzureCredential);
-            KeyVaultCertificateWithPolicy cert = certificateClient.GetCertificate(certificateIdentifier);
-
-            return cert.Cer;
+            var certificateClient = new CertificateClient(client.VaultUri, clientCredentials);
+            KeyVaultCertificateWithPolicy cert = certificateClient.GetCertificate(keyId);
+            return cert;
         }
-
     }
     #endregion
 
     #region signer
     public class AzureKeyVaultSigner : Pkcs7SignerBase
     {
-        // OID for RSA signature algorithm:
+        //OID for RSA signing algorithm:
         const string PKCS1RsaEncryption = "1.2.840.113549.1.1.1";
 
         readonly AzureKeyVaultClient keyVaultClient;
-        readonly string keyId;
-        readonly byte[][] certificateChain;
+        readonly KeyVaultCertificateWithPolicy certificate;
+        List<byte[]> certificateChain = new List<byte[]>();
 
 
-        // Must match with key algorithm (RSA or ECDSA)
-        // OID for RSA PKCS1RsaEncryption(1.2.840.113549.1.1.1) can have any digest algorithm
-        // For ECDSA, use OIDs from this family: http://oid-info.com/get/1.2.840.10045.4.3 
-        // Specified digest algorithm must be the same as to DigestCalculator algorithm
+        //Must match with key algorithm (RSA or ECDSA)
+        //For RSA PKCS1RsaEncryption(1.2.840.113549.1.1.1) OID can be used with any digest algorithm
+        //For ECDSA use OIDs from this family http://oid-info.com/get/1.2.840.10045.4.3 
+        //Specified digest algorithm must be same with DigestCalculator algorithm.
         protected override IDigestCalculator DigestCalculator => new DigestCalculator(HashAlgorithmType.SHA256); //Digest algorithm
         protected override string SigningAlgorithmOID => PKCS1RsaEncryption;
         protected override IEnumerable<byte[]> GetCertificates() => certificateChain;
 
-        public AzureKeyVaultSigner(AzureKeyVaultClient keyVaultClient, string certificateIdentifier, string keyId, string keyVaultUri, ITsaClient tsaClient = null,
-            IOcspClient ocspClient = null, ICrlClient crlClient = null,
-            PdfSignatureProfile profile = PdfSignatureProfile.Pdf) : base(tsaClient, ocspClient, crlClient, profile)
+        /// <summary>
+        /// Construct an instance of AzureKeyVaultSigner
+        /// </summary>
+        /// <param name="keyVaultClient">API client used to communicate with </param>
+        /// <param name="certificateName">The name of the Azure Certificate, will not contain any slashes</param>
+        /// <param name="certificateVersion">The version of the Azure Certificate, looks like a UUID. Leave empty/null to use the version labelled in Azure Portal as the "Current Version"</param>
+        /// <param name="tsaClient"></param>
+        /// <param name="ocspClient"></param>
+        /// <param name="crlClient"></param>
+        /// <param name="profile"></param>
+        /// <exception cref="System.ArgumentException"></exception>
+        public AzureKeyVaultSigner(AzureKeyVaultClient keyVaultClient, string certificateName, string certificateVersion = null, ITsaClient tsaClient = null, IOcspClient ocspClient = null, ICrlClient crlClient = null, PdfSignatureProfile profile = PdfSignatureProfile.PAdES_BES) : base(tsaClient, ocspClient, crlClient, profile)
         {
-            this.keyVaultClient = keyVaultClient;
-            this.keyId = keyId;
+            if (string.IsNullOrEmpty(certificateName))
+                throw new System.ArgumentException("Certificate name must not be null or empty.");
 
-            // Get certificate (without a public key) from Azure Key Vault storage
-            // or create a new one at runtime
-            // You can get the whole certificate chain here
-            certificateChain = new byte[][] { keyVaultClient.GetCertificateData(keyVaultUri, certificateIdentifier) };
+            if (certificateName.Contains('/'))
+                throw new System.ArgumentException("Invalid certificate name. Certificate name must not contain '/' character.");
+
+            if (certificateVersion != null && certificateVersion.Contains('/'))
+                throw new System.ArgumentException("Invalid certificate version. Certificate version must not contain '/' character.");
+
+            this.keyVaultClient = keyVaultClient;
+            //Get certificate (without public key) via GetCertificateAsync API
+            //You can get the whole certificate chain here
+            this.certificate = keyVaultClient.GetCertificateData($"{certificateName}/{certificateVersion}");
+            BuildCertificateChain();
         }
+
+        private void BuildCertificateChain()
+        {
+            var x509 = new X509Certificate2(certificate.Cer);
+            var chain = new X509Chain();
+            {
+                chain.Build(x509);
+
+                foreach (var item in chain.ChainElements)
+                    certificateChain.Add(item.Certificate.GetRawCertData());
+            }
+        }
+
         protected override byte[] SignDigest(byte[] digest)
         {
-            return keyVaultClient.Sign(keyId, SignatureAlgorithm.RS256, digest);
+            var signature = keyVaultClient.Sign(certificate.Name, SignatureAlgorithm.RS256, digest);
+            return signature;
         }
     }
     #endregion

--- a/CS/PdfAPIAzureKeyVaultSample/AzureKeyVaultClient.cs
+++ b/CS/PdfAPIAzureKeyVaultSample/AzureKeyVaultClient.cs
@@ -121,6 +121,9 @@ namespace PdfAPIAzureKeyVaultSample
 
         protected override byte[] SignDigest(byte[] digest)
         {
+            // use the name of the retrieved Certificate object to sign the digest
+            // as it may differ from the name used to retrieve the certificate if auto-selection occurred.
+            // https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning
             var signature = keyVaultClient.Sign(certificate.Name, SignatureAlgorithm.RS256, digest);
             return signature;
         }

--- a/CS/PdfAPIAzureKeyVaultSample/Program.cs
+++ b/CS/PdfAPIAzureKeyVaultSample/Program.cs
@@ -27,15 +27,23 @@ namespace PdfAPIAzureKeyVaultSample
                 // Specify your Azure Key Vault URL - (vaultUri)
                 const string keyVaultUrl = "";
 
-                // Specify the Azure Key Vault Certificate ID (certId)
-                string certificateId = "";
+                // Specify the Name of and Azure Key Vault Certificate (certId).
+                // This is listed in the "Name" column of your Azure Portal, Certificates page
+                string certificateName = "";
 
-                // Specify the Azure Key Vault Key ID for a certificate
-                string keyId = "";
+                // Specify the Version for the Azure Key Vault certificate.
+                // This is listed in the "Version" column of your Azure Portal, Certificates/[Certificate Name] page.
+                // Leave this empty, or null, to auto-select the "Current" version of the given certificate.
+                // Warning: Auto-selection will not "fall back" to a non-current certificate should the current certificate
+                //          be disabled, meaning that if the chosen certificate is disabled, signing will generate an error.  
+                string certificateVersion = "";
 
                 // Create a custom signer object:
-                var client = AzureKeyVaultClient.CreateClient(keyVaultUrl);
-                AzureKeyVaultSigner azureSigner = new AzureKeyVaultSigner(client, certificateId, keyId, keyVaultUrl, tsaClient);
+                var client = AzureKeyVaultClient.CreateClient(new Uri(keyVaultUrl));
+                AzureKeyVaultSigner azureSigner = new AzureKeyVaultSigner(client, 
+                    certificateName: certificateName, 
+                    certificateVersion: certificateVersion, 
+                    tsaClient);
 
                 // Apply a signature to a new form field:
                 var signatureBuilder = new PdfSignatureBuilder(azureSigner, description);


### PR DESCRIPTION
We have been using this code in production for some time. 
Our product encountered signing failures after uploading a certificate renewal to Azure, resulting in 2 versions of the cert in Azure Key Value. Investigations track it back primarily to the fact that in this code sample, the user supplied key id is passed to the signing API twice, once to retrieve the certificate, and a second time to perform the signing.
If auto-selection of the cert has occurred (which the current API allows you to do without realising, do to it's very loose contract design), then the key name passed to the signing operation may not match the actual key name passed to the Sign operation. As a result, signing succeeds, but the signature is invalid (shows up in Adobe Reader as an invalid signature).
Given that the Certificate object returned from Azure, contains both its name and version, it makes sense to use these values as the signing arguments - which takes care of the suto-selection problem - plus makes the code cleaner and easier to understand.

Only C# code - someones needs to write the equivalent VB.net changes.

Additionally cleaned up numerous inconsistencies.

The API did not align well with the underlying Azure class library API leading to confusion, and its structure lead to errors in usage we found in our production.
 - URI passed multiple times instead of being reused
 - key auto-selection not considered - where requested key (empty) is not the returned one, the operation would succeed, however the resulting signature would be invalid
 - constructor factory was a bit of a mess (visually)
 - unnecessary re-construction of credentials object
 - keyClient.getKey was not making use of the 'version' argument - loss of readability
 - client.Sign was passing user declared certificate name, instead of grabbing it from the actual certificate instance, leading to risk of mismatch causing invalid signature
 - improved naming of variables and arguments to reflect both their purpose, and the names used in Azure Portal to refer to values - i.e "Certificate Name" and "Certificate Version" vs "certId" and "keyId" which are very ambiguous